### PR TITLE
Console rename script and missing functions.php

### DIFF
--- a/_build/includes/functions.php
+++ b/_build/includes/functions.php
@@ -1,0 +1,8 @@
+<?php
+function getSnippetContent($filename) {
+    $o = file_get_contents($filename);
+    $o = trim(str_replace(array('<?php','?>'),'',$o));
+    return $o;
+}
+
+?>

--- a/rename_it
+++ b/rename_it
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+repl1=yourName
+repl2=yourname
+
+find1=modExtra
+find2=modextra
+path=./modExtra
+
+cd ..
+for i in {1..10} 
+do
+    find $path -name \*$find2\* -a ! -name rename_it | xargs perl -e 'for(@ARGV) { $a=$_; s/'$find2'/'$repl2'/g; rename $a,$_; print "$_\n" }'
+done
+
+for i in `egrep -r $find1 $path/_build $path/core $path/assets | grep -v svn | cut -d ":" -f1`
+do
+    reg="s/$find1/$repl1/g"
+    sed -e $reg $i > ${i}.bak
+    mv ${i}.bak $i
+
+    reg="s/$find2/$repl2/g"
+    sed -e $reg $i > ${i}.bak
+    mv ${i}.bak $i
+
+    echo $i
+done
+
+mv $find1 $repl1


### PR DESCRIPTION
I propose to add a script to quickly rename modExtra into whateverName

The coslole script is written in bash and quickly rename all modExtra and modextra in directory.
Requires perl.
